### PR TITLE
fix: Adds zoom icon to images that show larger image modal.

### DIFF
--- a/src/components/ImageWithModal.css
+++ b/src/components/ImageWithModal.css
@@ -11,6 +11,10 @@ button.modalButton {
   height: inherit;
 }
 
+button.modalZoom {
+  cursor: zoom-in;
+}
+
 button.modalButton:hover {
   background-color: transparent;
 }

--- a/src/components/ImageWithModal.jsx
+++ b/src/components/ImageWithModal.jsx
@@ -51,7 +51,7 @@ export default function ImageWithModal(props) {
 
   return (
     <>
-      <Button className="modalButton" onClick={() => setModalOpen(true)}>
+      <Button className="modalButton modalZoom" onClick={() => setModalOpen(true)}>
         <ImagePlaceholder
           src={signedThumbnailSrc}
           alt={title}


### PR DESCRIPTION
There are some images that show a modal of the image zoomed in and some
that show a detailed dataset, both had the link cursor and it was not as
clear which would show which. This adds a zoom icon to the images that
show a zoomed in image, to differentiate them from the other modals.

@krokicki 