### PR TITLE
curated matches

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@fortawesome/fontawesome-svg-core": "^6.4.0",
         "@fortawesome/free-brands-svg-icons": "^6.4.0",
         "@fortawesome/pro-regular-svg-icons": "^6.4.0",
+        "@fortawesome/pro-solid-svg-icons": "^6.4.0",
         "@fortawesome/react-fontawesome": "^0.2.0",
         "@testing-library/cypress": "^10.0.1",
         "@testing-library/jest-dom": "^5.16.5",
@@ -8764,6 +8765,25 @@
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "6.4.0"
       },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/pro-solid-svg-icons": {
+      "version": "6.7.1",
+      "resolved": "https://npm.fontawesome.com/@fortawesome/pro-solid-svg-icons/-/6.7.1/pro-solid-svg-icons-6.7.1.tgz",
+      "integrity": "sha512-YMehuODXC+puZRJigjfB+hwCeiUsfEfiDXJV0W1iSbrqX9xBbDl0Ovbnai3EUlwIVWpgfoWew6Cx207wwVAEnA==",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.7.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/pro-solid-svg-icons/node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.7.1",
+      "resolved": "https://npm.fontawesome.com/@fortawesome/fontawesome-common-types/-/6.7.1/fontawesome-common-types-6.7.1.tgz",
+      "integrity": "sha512-gbDz3TwRrIPT3i0cDfujhshnXO9z03IT1UKRIVi/VEjpNHtSBIP2o5XSm+e816FzzCFEzAxPw09Z13n20PaQJQ==",
       "engines": {
         "node": ">=6"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@fortawesome/fontawesome-svg-core": "^6.4.0",
         "@fortawesome/free-brands-svg-icons": "^6.4.0",
         "@fortawesome/pro-regular-svg-icons": "^6.4.0",
-        "@fortawesome/pro-solid-svg-icons": "^6.4.0",
+        "@fortawesome/pro-solid-svg-icons": "^6.7.1",
         "@fortawesome/react-fontawesome": "^0.2.0",
         "@testing-library/cypress": "^10.0.1",
         "@testing-library/jest-dom": "^5.16.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@babel/eslint-parser": "^7.22.7",
         "@fortawesome/fontawesome-svg-core": "^6.4.0",
         "@fortawesome/free-brands-svg-icons": "^6.4.0",
+        "@fortawesome/free-solid-svg-icons": "^7.2.0",
         "@fortawesome/pro-regular-svg-icons": "^6.4.0",
         "@fortawesome/pro-solid-svg-icons": "^6.7.1",
         "@fortawesome/react-fontawesome": "^0.2.0",
@@ -8754,6 +8755,27 @@
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "6.4.0"
       },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "7.2.0",
+      "resolved": "https://npm.fontawesome.com/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-7.2.0.tgz",
+      "integrity": "sha512-YTVITFGN0/24PxzXrwqCgnyd7njDuzp5ZvaCx5nq/jg55kUYd94Nj8UTchBdBofi/L0nwRfjGOg0E41d2u9T1w==",
+      "license": "(CC-BY-4.0 AND MIT)",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "7.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons/node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "7.2.0",
+      "resolved": "https://npm.fontawesome.com/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-7.2.0.tgz",
+      "integrity": "sha512-IpR0bER9FY25p+e7BmFH25MZKEwFHTfRAfhOyJubgiDnoJNsSvJ7nigLraHtp4VOG/cy8D7uiV0dLkHOne5Fhw==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@fortawesome/fontawesome-svg-core": "^6.4.0",
     "@fortawesome/free-brands-svg-icons": "^6.4.0",
     "@fortawesome/pro-regular-svg-icons": "^6.4.0",
-    "@fortawesome/pro-solid-svg-icons": "^6.4.0",
+    "@fortawesome/pro-solid-svg-icons": "^6.7.1",
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@testing-library/cypress": "^10.0.1",
     "@testing-library/jest-dom": "^5.16.5",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@fortawesome/fontawesome-svg-core": "^6.4.0",
     "@fortawesome/free-brands-svg-icons": "^6.4.0",
     "@fortawesome/pro-regular-svg-icons": "^6.4.0",
+    "@fortawesome/pro-solid-svg-icons": "^6.4.0",
     "@fortawesome/react-fontawesome": "^0.2.0",
     "@testing-library/cypress": "^10.0.1",
     "@testing-library/jest-dom": "^5.16.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neuronbridge",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "private": true,
   "dependencies": {
     "@ant-design/icons": "^5.1.4",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@babel/eslint-parser": "^7.22.7",
     "@fortawesome/fontawesome-svg-core": "^6.4.0",
     "@fortawesome/free-brands-svg-icons": "^6.4.0",
+    "@fortawesome/free-solid-svg-icons": "^7.2.0",
     "@fortawesome/pro-regular-svg-icons": "^6.4.0",
     "@fortawesome/pro-solid-svg-icons": "^6.7.1",
     "@fortawesome/react-fontawesome": "^0.2.0",

--- a/public/RELEASENOTES.md
+++ b/public/RELEASENOTES.md
@@ -4,64 +4,38 @@
 
   - **Curated Matches of Split-GAL4 Lines to Cell Types**: Search results now include a curated matches section that displays expert-annotated associations between Split-GAL4 lines and cell types
     - Results are shown in a collapsible, paginated table with confidence level (Confident/Candidate), anatomical region, and source columns
-    - Includes EM body ID annotations alongside cell type matches
     - Curated matches appear above computed matches with a bookmark indicator when results are available
-    - Supports searching by line name, cell type, or body ID with wildcard expansion
+    - See the [Curated Results section of the help page](/help#curated_results) for details on confidence levels and data sources.
 
   - **Line Name Links**: Line names in search result metadata are now clickable links that navigate to a new search for that line
 
 ### UI/UX Improvements
 
-  - **Search Input Updates**: The search button has been renamed from "Search" to "Query" and the minimum search term length has been reduced from 3 to 2 characters
   - **Updated Search Examples**: The example search terms have been refreshed to showcase curated matches functionality
-  - **Constrained Results Width**: Search results are now constrained to a maximum width for improved readability
   - **Help Documentation**: Added a new help section explaining the curated matches feature
-
-### Curated Results
-
-See the [Curated Results section of the help page](/help#curated_results) for details on confidence levels and data sources.
-
-### Content Updates
-
-  - Updated paper reference
-  - Added help text for curated matches
 
 ---
 
-## VERSION 3.4.0 - 2025-04-17
+## VERSION 3.4.0 - 2026-04-17
 
 ### Major Features
 
   - **Aligned Volume Download for Custom Searches**: Custom search results now include a download link for the aligned volume, making it easier to retrieve aligned data for further analysis
     - The "View in 3D" button is now available for custom uploads when an aligned volume exists
-    - The selected channel from mask selection is persisted to the search record
 
   - **Searched Libraries Display**: The Color Depth Search step now shows which libraries were searched along with result counts, providing better visibility into search coverage
 
 ### UI/UX Improvements
 
   - **External Links Open in New Tabs**: All links to external sources now open in a new tab, preventing users from losing their place on the site
-  - **External Link Icons**: An external link icon has been added to all external links, making it clear when a link will navigate away from NeuronBridge
-  - **Additional Data Source Links**: Two additional links have been added to the landing page data sources list
 
 ### Bug Fixes & Improvements
 
   - **Search & Navigation**:
     - Improved search result filtering and duplicate removal logic
-    - Fixed the default search library selection in the custom search form
     - Fixed external EM links to use id instead of library
     - Fixed the "View" button to be clickable anywhere on the button area
     - Updated search examples for accuracy
-
-  - **Stability & Error Handling**:
-    - Added null check for error responses in the Results catch handler
-    - Added cacheControl headers to references.json fetch for improved caching
-
-### Content Updates
-
-  - Added CITATION.cff for Zenodo integration
-  - Added reference for Male CNS
-  - Updated site meta description
 
 ---
 

--- a/public/RELEASENOTES.md
+++ b/public/RELEASENOTES.md
@@ -1,3 +1,33 @@
+## VERSION 3.5.0 - 2026-04-17
+
+### Major Features
+
+  - **Curated Matches of Split-GAL4 Lines to Cell Types**: Search results now include a curated matches section that displays expert-annotated associations between Split-GAL4 lines and cell types
+    - Results are shown in a collapsible, paginated table with confidence level (Confident/Candidate), anatomical region, and source columns
+    - Includes EM body ID annotations alongside cell type matches
+    - Curated matches appear above computed matches with a bookmark indicator when results are available
+    - Supports searching by line name, cell type, or body ID with wildcard expansion
+
+  - **Line Name Links**: Line names in search result metadata are now clickable links that navigate to a new search for that line
+
+### UI/UX Improvements
+
+  - **Search Input Updates**: The search button has been renamed from "Search" to "Query" and the minimum search term length has been reduced from 3 to 2 characters
+  - **Updated Search Examples**: The example search terms have been refreshed to showcase curated matches functionality
+  - **Constrained Results Width**: Search results are now constrained to a maximum width for improved readability
+  - **Help Documentation**: Added a new help section explaining the curated matches feature
+
+### Curated Results
+
+See the [Curated Results section of the help page](/help#curated_results) for details on confidence levels and data sources.
+
+### Content Updates
+
+  - Updated paper reference
+  - Added help text for curated matches
+
+---
+
 ## VERSION 3.4.0 - 2025-04-17
 
 ### Major Features

--- a/public/RELEASENOTES.md
+++ b/public/RELEASENOTES.md
@@ -1,3 +1,40 @@
+## VERSION 3.4.0 - 2025-04-17
+
+### Major Features
+
+  - **Aligned Volume Download for Custom Searches**: Custom search results now include a download link for the aligned volume, making it easier to retrieve aligned data for further analysis
+    - The "View in 3D" button is now available for custom uploads when an aligned volume exists
+    - The selected channel from mask selection is persisted to the search record
+
+  - **Searched Libraries Display**: The Color Depth Search step now shows which libraries were searched along with result counts, providing better visibility into search coverage
+
+### UI/UX Improvements
+
+  - **External Links Open in New Tabs**: All links to external sources now open in a new tab, preventing users from losing their place on the site
+  - **External Link Icons**: An external link icon has been added to all external links, making it clear when a link will navigate away from NeuronBridge
+  - **Additional Data Source Links**: Two additional links have been added to the landing page data sources list
+
+### Bug Fixes & Improvements
+
+  - **Search & Navigation**:
+    - Improved search result filtering and duplicate removal logic
+    - Fixed the default search library selection in the custom search form
+    - Fixed external EM links to use id instead of library
+    - Fixed the "View" button to be clickable anywhere on the button area
+    - Updated search examples for accuracy
+
+  - **Stability & Error Handling**:
+    - Added null check for error responses in the Results catch handler
+    - Added cacheControl headers to references.json fetch for improved caching
+
+### Content Updates
+
+  - Added CITATION.cff for Zenodo integration
+  - Added reference for Male CNS
+  - Updated site meta description
+
+---
+
 ## VERSION 3.3.1 - 2024-09-22
 
 ### Major Features

--- a/src/App.css
+++ b/src/App.css
@@ -74,3 +74,11 @@ body {
   list-style: none;
   padding: 0;
 }
+
+/* hides the anchor offset on any page that needs it */
+.anchorOffset {
+  display: block;
+  position: relative;
+  top: -80px;
+  visibility: hidden;
+}

--- a/src/components/CuratedResults.jsx
+++ b/src/components/CuratedResults.jsx
@@ -79,7 +79,7 @@ export default function CuratedResults({ searchTerm }) {
   return (
     <Card
       title="Curated Results"
-      extra={<HelpButton target="SearchInput" />}
+      extra={<HelpButton target="CuratedResults" />}
       style={{ marginBottom: "2em", position: "relative" }}
     >
       <FontAwesomeIcon

--- a/src/components/CuratedResults.jsx
+++ b/src/components/CuratedResults.jsx
@@ -1,0 +1,102 @@
+import { useState, useEffect } from "react";
+import PropTypes from "prop-types";
+import { Card, Table } from "antd";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faBookmark } from "@fortawesome/pro-solid-svg-icons";
+import { Link } from "react-router-dom";
+
+import HelpButton from "./Help/HelpButton";
+
+const columns = [
+  {
+    title: "Line Name",
+    dataIndex: "name",
+    key: "name",
+  },
+  {
+    title: "Confidence",
+    dataIndex: "confidence",
+    key: "confidence",
+  },
+  {
+    title: "Anatomical Region",
+    dataIndex: "anatomicalRegion",
+    key: "anatomicalRegion",
+  },
+  {
+    title: "Cell Type",
+    dataIndex: "cellType",
+    key: "cellType",
+    render: (cellType) => <Link to={`/search?q=${cellType}`}>{cellType}</Link>,
+  },
+];
+
+export default function CuratedResults({ searchTerm }) {
+  const [results, setResults] = useState([]);
+
+  // use the searchTerm to fetch curated results from DynamoDB?
+  useEffect(() => {
+    // fetch results from DynamoDB
+    setResults([
+      {
+        key: "1",
+        name: "MB018B",
+        confidence: "candidate",
+        anatomicalRegion: "Brain",
+        cellType: "KCg-d",
+      },
+      {
+        key: "2",
+        name: "MB018B",
+        confidence: "candiate",
+        anatomicalRegion: "Brain",
+        cellType: "KCg-m",
+      },
+      {
+        key: "3",
+        name: "MB018B",
+        confidence: "confident",
+        anatomicalRegion: "Brain",
+        cellType: "MBON13",
+      },
+    ]);
+  }, [searchTerm]);
+
+  // if we found anything, then display it in a table above the rest of the results.
+  // if we're still waiting for the fetch to complete, then display a loading spinner.
+  // if there was an error, then display an error message.
+
+  // if the user has not yet entered a search term, then don't display anything.
+  if (!searchTerm) {
+    return null;
+  }
+
+  // if we didn't find anything, then don't display anything.
+  if (results.length === 0) {
+    return null;
+  }
+
+  return (
+    <Card
+      title="Curated Results"
+      extra={<HelpButton target="SearchInput" />}
+      style={{ marginBottom: "2em", position: "relative" }}
+    >
+      <FontAwesomeIcon
+        icon={faBookmark}
+        style={{
+          position: "absolute",
+          top: "-3px",
+          left: "5px",
+          color: "#f00",
+          fontSize: "1.5em",
+        }}
+      />
+      <Table columns={columns} dataSource={results} pagination={false} />
+    </Card>
+  );
+}
+
+CuratedResults.propTypes = {
+  searchTerm: PropTypes.string.isRequired,
+};

--- a/src/components/CuratedResults.jsx
+++ b/src/components/CuratedResults.jsx
@@ -37,6 +37,17 @@ export default function CuratedResults({ results, loadError }) {
     return null;
   }
 
+  let pagination = {
+    position: ['topLeft'],
+    showSizeChanger: true,
+    showQuickJumper: true,
+    showTotal: (total) => `Total ${total} items`,
+  };
+
+  if (results.length < 6) {
+    pagination = false;
+  } 
+
   if (loadError) {
     return (
       <Card
@@ -59,7 +70,7 @@ export default function CuratedResults({ results, loadError }) {
     );
   }
 
-  return <Table columns={columns} dataSource={results} pagination={false} />;
+  return <Table columns={columns} dataSource={results} pagination={pagination} />;
 }
 
 CuratedResults.propTypes = {

--- a/src/components/CuratedResults.jsx
+++ b/src/components/CuratedResults.jsx
@@ -41,17 +41,16 @@ export default function CuratedResults({ results, loadError }) {
   }
 
   let pagination = {
-    position: ['topLeft'],
-    pageSizeOptions: ['2', '5', '10', '15', '20'],
+    position: ["topLeft"],
+    pageSizeOptions: ["2", "5", "10", "15", "20"],
     defaultPageSize: 2,
     showSizeChanger: true,
-    showQuickJumper: true,
-    showTotal: (total) => `Total ${total} items`,
+    showQuickJumper: true
   };
 
-  if (results.length < 6) {
+  if (results.length < 3) {
     pagination = false;
-  } 
+  }
 
   if (loadError) {
     return (
@@ -71,10 +70,12 @@ export default function CuratedResults({ results, loadError }) {
     );
   }
 
-  return <Table columns={columns} dataSource={results} pagination={pagination} />;
+  return (
+    <Table columns={columns} dataSource={results} pagination={pagination} />
+  );
 }
 
 CuratedResults.propTypes = {
-  results: PropTypes.array.isRequired,
+  results: PropTypes.arrayOf(PropTypes.object).isRequired,
   loadError: PropTypes.bool.isRequired,
 };

--- a/src/components/CuratedResults.jsx
+++ b/src/components/CuratedResults.jsx
@@ -22,6 +22,11 @@ const columns = [
     key: "anatomicalRegion",
   },
   {
+    title: "Source",
+    dataIndex: "source",
+    key: "source",
+  },
+  {
     title: "Cell Type",
     dataIndex: "cellType",
     key: "cellType",

--- a/src/components/CuratedResults.jsx
+++ b/src/components/CuratedResults.jsx
@@ -42,8 +42,8 @@ export default function CuratedResults({ results, loadError }) {
 
   let pagination = {
     position: ['topLeft'],
-    pageSizeOptions: ['5', '10', '15', '20'],
-    defaultPageSize: 5,
+    pageSizeOptions: ['2', '5', '10', '15', '20'],
+    defaultPageSize: 2,
     showSizeChanger: true,
     showQuickJumper: true,
     showTotal: (total) => `Total ${total} items`,

--- a/src/components/CuratedResults.jsx
+++ b/src/components/CuratedResults.jsx
@@ -27,7 +27,7 @@ const columns = [
     key: "source",
   },
   {
-    title: "Cell Type",
+    title: "Cell Type / Neuron ID",
     dataIndex: "cellType",
     key: "cellType",
     render: (cellType) => <Link to={`/search?q=${cellType}`}>{cellType}</Link>,

--- a/src/components/CuratedResults.jsx
+++ b/src/components/CuratedResults.jsx
@@ -39,6 +39,8 @@ export default function CuratedResults({ results, loadError }) {
 
   let pagination = {
     position: ['topLeft'],
+    pageSizeOptions: ['5', '10', '15', '20'],
+    defaultPageSize: 5,
     showSizeChanger: true,
     showQuickJumper: true,
     showTotal: (total) => `Total ${total} items`,

--- a/src/components/CuratedResults.jsx
+++ b/src/components/CuratedResults.jsx
@@ -28,9 +28,16 @@ const columns = [
   },
   {
     title: "Cell Type / Neuron ID",
-    dataIndex: "cellType",
-    key: "cellType",
-    render: (cellType) => <Link to={`/search?q=${cellType}`}>{cellType}</Link>,
+    dataIndex: "matched",
+    key: "matched",
+    render: (matched, row) => {
+      // if the match is a cell type, then we add a wildcard to the search
+      // to get all the sub cell types.
+      if (row.type === 'cell_type') {
+        return <Link to={`/search?q=${matched}*`}>{matched}</Link>;
+      }
+      return <Link to={`/search?q=${matched}`}>{matched}</Link>;
+    }
   },
 ];
 

--- a/src/components/CuratedResults.jsx
+++ b/src/components/CuratedResults.jsx
@@ -1,8 +1,6 @@
 import PropTypes from "prop-types";
-import { Card, Table, Typography } from "antd";
+import { Table, Typography } from "antd";
 import { Link } from "react-router-dom";
-
-import HelpButton from "./Help/HelpButton";
 
 const { Paragraph } = Typography;
 
@@ -52,11 +50,7 @@ export default function CuratedResults({ results, loadError }) {
 
   if (loadError) {
     return (
-      <Card
-        title="Curated Matches"
-        extra={<HelpButton target="CuratedResults" />}
-        style={{ marginBottom: "2em" }}
-      >
+      <>
         <Paragraph type="danger">
           There was a problem retrieving the curated matches.
         </Paragraph>
@@ -68,7 +62,7 @@ export default function CuratedResults({ results, loadError }) {
           </a>
           . Please provide the search term used and any other relevant details.
         </Paragraph>
-      </Card>
+      </>
     );
   }
 

--- a/src/components/CuratedResults.jsx
+++ b/src/components/CuratedResults.jsx
@@ -43,7 +43,7 @@ export default function CuratedResults({ results, loadError }) {
   }
 
   let pagination = {
-    position: ["topLeft"],
+    position: ["bottomLeft"],
     pageSizeOptions: ["2", "5", "10", "15", "20"],
     defaultPageSize: 2,
     showSizeChanger: true,

--- a/src/components/CuratedResults.jsx
+++ b/src/components/CuratedResults.jsx
@@ -30,14 +30,9 @@ const columns = [
     title: "Cell Type / Neuron ID",
     dataIndex: "matched",
     key: "matched",
-    render: (matched, row) => {
-      // if the match is a cell type, then we add a wildcard to the search
-      // to get all the sub cell types.
-      if (row.type === 'cell_type') {
-        return <Link to={`/search?q=${matched}*`}>{matched}</Link>;
-      }
-      return <Link to={`/search?q=${matched}`}>{matched}</Link>;
-    }
+    // if the match is a cell type, then we add a wildcard to the search
+    // to get all the sub cell types.
+    render: (matched, row) => <Link to={`/search?q=${matched}${row.addWildard}`}>{matched}</Link>,
   },
 ];
 

--- a/src/components/Help/HelpButton.jsx
+++ b/src/components/Help/HelpButton.jsx
@@ -6,10 +6,17 @@ import { AppContext } from "../../containers/AppContext";
 export default function HelpButton({target, text, onClick}) {
   const { appState, setAppState } = useContext(AppContext);
 
-  const handleHelp = () => {
+  const handleHelp = (event) => {
+    // call the onClick callback if it is provided
     if (onClick) {
-      onClick();
+      onClick(event);
     }
+    // Toggle help if the button is clicked again
+    if (appState.helpTarget === target) {
+      setAppState({ ...appState, showHelp: !appState.showHelp });
+      return;
+    }
+    // Show help for the target
     setAppState({ ...appState, showHelp: true, helpTarget: target });
   }
 

--- a/src/components/Help/HelpContents.jsx
+++ b/src/components/Help/HelpContents.jsx
@@ -34,29 +34,24 @@ export default function HelpContents({ scroll }) {
     SearchInput: useRef(),
     UploadAlignment: useRef(),
     UploadSearch: useRef(),
+    CuratedResults: useRef(),
   };
 
   // use Effect to scroll to target set in the appState?
   useEffect(() => {
     if (scroll) {
-      if (refLookup[appState.helpTarget]) {
-        if (refLookup[appState.helpTarget].current) {
-          helpContentRef.current.parentElement.scrollTop =
-            refLookup[appState.helpTarget].current.offsetTop - 60;
-          refLookup[appState.helpTarget].current.classList.add("highlighted");
-          window.setTimeout(() => {
-            if (
-              refLookup[appState.helpTarget] &&
-              refLookup[appState.helpTarget].current
-            ) {
-              refLookup[appState.helpTarget].current.classList.remove(
-                "highlighted"
-              );
-            }
-          }, 3000);
+      const observer = new IntersectionObserver(([entry]) => {
+        if (entry.isIntersecting) {
+          refLookup[appState.helpTarget].current.scrollIntoView({ behavior: "instant" });
+          observer.disconnect();
         }
+      });
+      observer.observe(helpContentRef.current);
+      return () => {
+        observer.disconnect();
       }
     }
+    return () => {};
   }, [appState.helpTarget, refLookup, scroll]);
 
   const handleResultsPerLine = (count) => {
@@ -324,6 +319,22 @@ export default function HelpContents({ scroll }) {
           </a>
         </p>
       </div>
+      <Divider />
+      <a
+        ref={refLookup.CuratedResults}
+        className="anchorOffset"
+        id="curated_results"
+        href="#curated_results"
+      >
+        #curated_results
+      </a>
+      <Title level={3}>Curated Results</Title>
+      <p>
+        Curated results show detailed information about... 
+      </p>
+
+
+
       <Divider />
       <a
         ref={refLookup.UploadAlignment}

--- a/src/components/Help/HelpContents.jsx
+++ b/src/components/Help/HelpContents.jsx
@@ -330,11 +330,22 @@ export default function HelpContents({ scroll }) {
       </a>
       <Title level={3}>Curated Results</Title>
       <p>
-        Curated results show detailed information about... 
+      Curated results are based on human evaluations of EM cell types labeled in LM images of split-GAL4 lines. In general they should be more accurate than the average NeuronBridge image search hit. The name of the primary person evaluating the cell type is listed. 
       </p>
+      <p>
+      Curated results come from two sources:
+      <ul>
+        <li>Annotations generated as part of split-GAL4 publications, and included with releases posted to <a href="https://splitgal4.janelia.org">https://splitgal4.janelia.org</a>.</li>
+        <li>Scoring of PatchPerPixMatch EM search results for a subset of the cell type lines published in <a href="https://doi.org/10.7554/elife.98405.3">Meissner et al., 2025</a>. These scores and additional details may be published in a forthcoming standalone paper or addendum to the above paper.</li>
+      </ul>
 
-
-
+      Results have one of three confidence levels: 
+      <ul>
+        <li>Confident: &gt;95% confidence, based on detailed examination of all potential associations, similar to criteria for publication.</li>
+        <li>Probable: 70-95% confidence, an association that seems correct but has not been as fully validated.</li>
+        <li>Candidate: 30-70% confidence, where more work is needed for validation and there are often multiple candidates.</li>
+      </ul>
+      </p>
       <Divider />
       <a
         ref={refLookup.UploadAlignment}

--- a/src/components/HelpPage.css
+++ b/src/components/HelpPage.css
@@ -12,9 +12,4 @@
   }
 }
 
-.anchorOffset {
-  display: block;
-  position: relative;
-  top: -80px;
-  visibility: hidden;
-}
+

--- a/src/components/LineMeta.jsx
+++ b/src/components/LineMeta.jsx
@@ -54,7 +54,7 @@ export default function LineMeta({ attributes, compact, fromSearch }) {
     return (
       <p>
         <b>Line Name: </b>
-        <span>{publishedName}</span>
+        <Link to={`/search?q=${publishedName}`}>{publishedName}</Link>
       </p>
     );
   }
@@ -64,7 +64,7 @@ export default function LineMeta({ attributes, compact, fromSearch }) {
       <Col md={24} lg={12}>
         <p>
           <b>Line Name: </b>
-          <span>{publishedName}</span>
+          <Link to={`/search?q=${publishedName}`}>{publishedName}</Link>
         </p>
         {attributes.normalizedScore ? (
           <p>

--- a/src/components/References.jsx
+++ b/src/components/References.jsx
@@ -188,7 +188,7 @@ export default function References() {
 
       <dt>Raw (uncurated) Split-GAL4 Lines</dt>
       <dd>
-        <a href="https://doi.org/10.1101/2024.01.09.574419" target="_blank" rel="noopener noreferrer">Meissner et al., 2024 <FontAwesomeIcon icon={faExternalLink} size="xs" /></a>
+        <a href="https://doi.org/10.7554/elife.98405.3" target="_blank" rel="noopener noreferrer">Meissner et al., 2025 <FontAwesomeIcon icon={faExternalLink} size="xs" /></a>
       </dd>
 
       <dt>FlyWire</dt>

--- a/src/components/ScrollToTopOnMount.jsx
+++ b/src/components/ScrollToTopOnMount.jsx
@@ -2,6 +2,14 @@ import { useEffect } from "react";
 
 function ScrollToTopOnMount() {
   useEffect(() => {
+    const { hash } = window.location;
+    if (hash) {
+      const element = document.getElementById(hash.slice(1));
+      if (element) {
+        element.scrollIntoView();
+        return;
+      }
+    }
     window.scrollTo(0, 0);
   }, []);
 

--- a/src/components/Search.jsx
+++ b/src/components/Search.jsx
@@ -24,14 +24,14 @@ function Search() {
       if (!searchTerm) {
         return;
       }
-      if (searchTerm.length < 3) {
+      if (searchTerm.length < 2) {
         message.error({
           duration: 0,
-          content: "Searches must have a minimum of 3 characters.",
+          content: "Searches must have a minimum of 2 characters.",
           key: "searchminimum",
           onClick: () => message.destroy("searchminimum"),
         });
-        setResults({ error: "Searches must have a minimum of 3 characters." });
+        setResults({ error: "Searches must have a minimum of 2 characters." });
         return;
       }
       if (searchTerm.match(/\*(\*|\.)\*/)) {

--- a/src/components/SearchInput.jsx
+++ b/src/components/SearchInput.jsx
@@ -77,9 +77,9 @@ export default function SearchInput({ searchTerm, examples, uploads, help }) {
           >
             <Search
               placeholder="Search with a line name, neuron ID, or neuron name."
-              enterButton="Search"
+              enterButton="Query"
               onSearch={handleSearch}
-              aria-label="Search"
+              aria-label="Query"
               size="large"
               onPressEnter={e => {
                 if (!dropDownOpen) {

--- a/src/components/SearchInput.jsx
+++ b/src/components/SearchInput.jsx
@@ -48,9 +48,8 @@ export default function SearchInput({ searchTerm, examples, uploads, help }) {
     setSearch(searchText);
   };
 
-  const exampleIds = process.env.REACT_APP_LEVEL && process.env.REACT_APP_LEVEL.match(/pre$/i)
-    ? ["1537331894","720575940630770042","512929","AN09B007","MBON05","*adt*","R33C10","VT002996"]
-    : ["1537331894","720575940630770042","512929","AN09B007","MBON05","*adt*","R33C10","VT002996"];
+  const ids = ["1537331894","SS65417","MBON05","ER3a_a","12191","SLP374","720575940630770042","*adt*"];
+  const exampleIds = process.env.REACT_APP_LEVEL && process.env.REACT_APP_LEVEL.match(/pre$/i) ? ids : ids;
 
   const exampleLinks = exampleIds.map((id, i) => {
     const url = `/search?q=${id}`;

--- a/src/components/SkeletonMeta.jsx
+++ b/src/components/SkeletonMeta.jsx
@@ -18,11 +18,22 @@ function NeuronTypeOrAnnotation({ attributes }) {
     );
   }
 
-  const neuronTypeAndInstance = `${neuronType || "-"} / ${neuronInstance || "-"}`;
+  const typeLink = neuronType ? (
+    <Link to={`/search?q=${neuronType}`}>{neuronType}</Link>
+  ) : (
+    "-"
+  );
+
+  const instanceLink = neuronInstance ? (
+    <Link to={`/search?q=${neuronInstance}`}>{neuronInstance}</Link>
+  ) : (
+    "-"
+  );
+
   return (
     <p>
       <b>Neuron Type / Instance: </b>
-      <br /> {neuronTypeAndInstance}
+      <br /> {typeLink} / {instanceLink}
     </p>
   );
 }

--- a/src/components/UnifiedSearch.jsx
+++ b/src/components/UnifiedSearch.jsx
@@ -37,7 +37,8 @@ function filterAndSortCuratedMatches(matches) {
           name: match.name,
           confidence: m.annotation,
           anatomicalRegion: m.region,
-          cellType,
+          matched: cellType,
+          type: "line_name",
           source: m.annotator,
         };
       });
@@ -47,7 +48,8 @@ function filterAndSortCuratedMatches(matches) {
         name: m.line,
         confidence: m.annotation,
         anatomicalRegion: m.region,
-        cellType: match.name,
+        matched: match.name,
+        type: "cell_type",
         source: m.annotator,
       }));
     }
@@ -56,7 +58,8 @@ function filterAndSortCuratedMatches(matches) {
         name: m.line,
         confidence: m.annotation,
         anatomicalRegion: m.region,
-        cellType:`${m.dataset}:${match.name}`,
+        matched:`${m.dataset}:${match.name}`,
+        type: "body_id",
         source: m.annotator,
       }));
     }

--- a/src/components/UnifiedSearch.jsx
+++ b/src/components/UnifiedSearch.jsx
@@ -32,13 +32,15 @@ function filterAndSortCuratedMatches(matches) {
   const expanded = matches.flatMap((match) => {
     if (match.itemType === "line_name") {
       return match.matches.map((m) => {
-        const cellType = m.cell_type || `${m.dataset}:${m.body_id}`;
+        const matched = m.cell_type || `${m.dataset}:${m.body_id}`;
+        const addWildard = m.cell_type ? "*" : "";
         return {
           name: match.name,
           confidence: m.annotation,
           anatomicalRegion: m.region,
-          matched: cellType,
+          matched,
           type: "line_name",
+          addWildard,
           source: m.annotator,
         };
       });
@@ -50,6 +52,7 @@ function filterAndSortCuratedMatches(matches) {
         anatomicalRegion: m.region,
         matched: match.name,
         type: "cell_type",
+        addWildard: "*",
         source: m.annotator,
       }));
     }
@@ -60,6 +63,7 @@ function filterAndSortCuratedMatches(matches) {
         anatomicalRegion: m.region,
         matched:`${m.dataset}:${match.name}`,
         type: "body_id",
+        addWildard: "",
         source: m.annotator,
       }));
     }

--- a/src/components/UnifiedSearch.jsx
+++ b/src/components/UnifiedSearch.jsx
@@ -214,6 +214,8 @@ export default function UnifiedSearch() {
 
       Auth.currentCredentials().then(() => {
         setLoadError(false);
+
+
         API.get("SearchAPI", "/published_names", {
           queryStringParameters: { q: searchBodyIdOrName },
         })
@@ -221,6 +223,8 @@ export default function UnifiedSearch() {
             const lineCombined = { results: [] };
             const bodyCombined = { results: [] };
             const publishedNames = new Set();
+
+            const seenIds = new Set();
 
             const allItems = items.names
               .sort((a, b) => {
@@ -267,7 +271,14 @@ export default function UnifiedSearch() {
                 ) {
                   return match.bodyIDs.map((body) => {
                     publishedNames.add(body);
-                    const bodyID = body.split(":").at(-1);
+                    const [bodyID] = Object.entries(body)[0];
+                    // skip if we have already seen this bodyID in one of the other
+                    // matches. This happens when we use wildcard searches that return
+                    // results for both the neuron type and the neuron instance. eg: LHPD2c7*
+                    if (seenIds.has(bodyID)) {
+                      return Promise.resolve();
+                    }
+                    seenIds.add(bodyID);
                     const byBodyUrl = `${appState.dataVersion}/metadata/by_body/${bodyID}.json`;
                     return Storage.get(byBodyUrl, storageOptions)
                       .then((metaData) =>
@@ -291,6 +302,10 @@ export default function UnifiedSearch() {
 
             // once all the items have loaded, we can clean up.
             allPromisses.then(() => {
+              // Set the foundItems count to the total number of items found
+              // in the search results. This is used to determine if we need to
+              // show the 'additional matches' message.
+              setFoundItems(bodyCombined.results.length);
               // remove duplicates from the combined results. This can happen if we are
               // loading data from a partial neurontype string, eg: WED01
               if (bodyCombined.results.length > 0) {
@@ -319,13 +334,14 @@ export default function UnifiedSearch() {
                   !searchDataset.includes(":")
                 ) {
                   bodyCombined.results = bodyCombined.results.filter((item) => {
-                    const [dataset, version, bodyid] =
-                      item.publishedName.split(":");
+                    const [dataset, , bodyid] = item.publishedName.split(":");
                     const noVersion = `${dataset}:${bodyid}`;
                     return noVersion.match(searchRegex);
                   });
                   // filter out items that don't match the original searchTerm if a
-                  // dataset and version was used.
+                  // dataset and version was used. For example, if the search term
+                  // was 'manc:v1.2.1:12191' then we want to filter out any results
+                  // that don't match the full search term, such as 'manc:v1.0:12191'
                 } else if (searchDataset && searchDataset.length > 0) {
                   bodyCombined.results = bodyCombined.results.filter((item) =>
                     item.publishedName.match(searchRegex),

--- a/src/components/UnifiedSearch.jsx
+++ b/src/components/UnifiedSearch.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useContext } from "react";
 import { useLocation, Link } from "react-router-dom";
 import { Storage, Auth, API } from "aws-amplify";
-import { Spin,  message, Typography } from "antd";
+import { Spin, message, Typography } from "antd";
 
 import SearchInput from "./SearchInput";
 import UnifiedSearchResults from "./UnifiedSearchResults";
@@ -67,7 +67,7 @@ export default function UnifiedSearch() {
       });
     }
 
-     if (appState.dataConfig.loaded && loadedTerm !== searchTerm) {
+    if (appState.dataConfig.loaded && loadedTerm !== searchTerm) {
       setLoadedTerm(searchTerm);
       setByLineResults(null);
       setByBodyResults(null);
@@ -228,14 +228,19 @@ export default function UnifiedSearch() {
                 // have a colon in it. A missing colon means it does not require a match to
                 // the dataset version, so the version is removed from the publishedName
                 // in the match and then checked against the search term.
-                if (searchDataset && searchDataset.length > 0 && !searchDataset.includes(":")) {
+                if (
+                  searchDataset &&
+                  searchDataset.length > 0 &&
+                  !searchDataset.includes(":")
+                ) {
                   bodyCombined.results = bodyCombined.results.filter((item) => {
-                    const [dataset, ,bodyid] = item.publishedName.split(":");
+                    const [dataset, version, bodyid] =
+                      item.publishedName.split(":");
                     const noVersion = `${dataset}:${bodyid}`;
                     return noVersion.match(searchRegex);
                   });
-                // filter out items that don't match the original searchTerm if a
-                // dataset and version was used.
+                  // filter out items that don't match the original searchTerm if a
+                  // dataset and version was used.
                 } else if (searchDataset && searchDataset.length > 0) {
                   bodyCombined.results = bodyCombined.results.filter((item) =>
                     item.publishedName.match(searchRegex),
@@ -287,12 +292,23 @@ export default function UnifiedSearch() {
     <div>
       <SearchInput searchTerm={searchTerm} />
       {!searchTerm ? <NoSearch /> : ""}
+      {searchTerm ? (
+        <>
+          <CuratedResults searchTerm={searchTerm} />
+          <h2 className="antd-card-head-title">Computed Image Matches</h2>
+        </>
+      ) : (
+        ""
+      )}
       {(lineLoading || bodyLoading) && !loadError ? (
         <div>
-          <Spin size="large" /> Loading...
-        </div>) : ""}
+          <Spin tip="Loading..." size="large" /> Loading...
+        </div>
+      ) : (
+        ""
+      )}
       {loadError ? searchError : ""}
-      {searchTerm ? <CuratedResults searchTerm={searchTerm} /> : ""}
+
       {byLineResult && byBodyResult && !lineLoading && !bodyLoading ? (
         <>
           <UnifiedSearchResults
@@ -303,8 +319,8 @@ export default function UnifiedSearch() {
           {foundItems > byBodyResult.results.length ? (
             <p>
               <b>
-                There are additional matches for your search term in different datasets. To view them
-                search for &lsquo;
+                There are additional matches for your search term in different
+                datasets. To view them search for &lsquo;
                 <Link to={`/search?q=${searchBodyIdOrName}`}>
                   {searchBodyIdOrName}
                 </Link>

--- a/src/components/UnifiedSearch.jsx
+++ b/src/components/UnifiedSearch.jsx
@@ -417,7 +417,7 @@ export default function UnifiedSearch() {
   if (curatedResults.length > 0) {
     items.unshift({
       key: "1",
-      label: "Curated Matches",
+      label: "Curated Matches of Split-GAL4 Lines to Cell Types",
       children: curatedMatches,
       extra: (
         <HelpButton

--- a/src/components/UnifiedSearch.jsx
+++ b/src/components/UnifiedSearch.jsx
@@ -411,7 +411,7 @@ export default function UnifiedSearch() {
   if (curatedResults.length > 0) {
     items.unshift({
       key: "1",
-      label: "Curated Matches of Split-GAL4 Lines to Cell Types",
+      label: `Curated Matches of Split-GAL4 Lines to Cell Types (${curatedResults.length} items)`,
       children: curatedMatches,
       extra: (
         <HelpButton

--- a/src/components/UnifiedSearch.jsx
+++ b/src/components/UnifiedSearch.jsx
@@ -5,6 +5,7 @@ import { Spin,  message, Typography } from "antd";
 
 import SearchInput from "./SearchInput";
 import UnifiedSearchResults from "./UnifiedSearchResults";
+import CuratedResults from "./CuratedResults";
 import NoSearch from "./NoSearch";
 import { AppContext } from "../containers/AppContext";
 import { setResultsFullUrlPaths } from "../libs/utils";
@@ -291,6 +292,7 @@ export default function UnifiedSearch() {
           <Spin size="large" /> Loading...
         </div>) : ""}
       {loadError ? searchError : ""}
+      {searchTerm ? <CuratedResults searchTerm={searchTerm} /> : ""}
       {byLineResult && byBodyResult && !lineLoading && !bodyLoading ? (
         <>
           <UnifiedSearchResults

--- a/src/components/UnifiedSearch.jsx
+++ b/src/components/UnifiedSearch.jsx
@@ -156,24 +156,25 @@ export default function UnifiedSearch() {
 
       // don't let people search with strings shorter than 3 characters.
       // This returns too many results.
-      if (searchTerm.length < 3) {
+      if (searchTerm.length < 2) {
         message.error({
           duration: 0,
-          content: "Searches must have a minimum of 3 characters.",
+          content: "Searches must have a minimum of 2 characters.",
           key: "searchminimum",
           onClick: () => message.destroy("searchminimum"),
         });
 
         setByLineResults({
-          error: "Searches must have a minimum of 3 characters.",
+          error: "Searches must have a minimum of 2 characters.",
           results: [],
         });
         setByBodyResults({
-          error: "Searches must have a minimum of 3 characters.",
+          error: "Searches must have a minimum of 2 characters.",
           results: [],
         });
         return;
       }
+
       if (searchTerm.match(/\*(\*|\.)\*/)) {
         message.error({
           duration: 0,
@@ -338,7 +339,17 @@ export default function UnifiedSearch() {
               setBodyLoading(false);
             });
           })
-          .catch((e) => setLoadError(e));
+          .catch((e) => {
+            message.error({
+              duration: 0,
+              content: e?.response?.data?.error || "There was a problem contacting the search service.",
+              key: "curated_error",
+              onClick: () => message.destroy("curated_error"),
+            });
+
+
+            setLoadError(true);
+          });
       });
     }
   }, [
@@ -368,6 +379,13 @@ export default function UnifiedSearch() {
           })
           .catch((error) => {
             setCuratedError(error);
+            message.error({
+              duration: 0,
+              content: error?.response?.data?.error || "There was a problem contacting the search service.",
+              key: "curated_error",
+              onClick: () => message.destroy("curated_error"),
+            });
+
           });
       });
     }

--- a/src/components/UnifiedSearch.jsx
+++ b/src/components/UnifiedSearch.jsx
@@ -474,7 +474,7 @@ export default function UnifiedSearch() {
   if (curatedResults.length > 0) {
     items.unshift({
       key: "1",
-      label: `Curated Matches of Split-GAL4 Lines to Cell Types (${curatedResults.length} items)`,
+      label: <p>Curated Matches of Split-GAL4 Lines to Cell Types <b>({curatedResults.length} items)</b></p>,
       children: curatedMatches,
       extra: (
         <HelpButton

--- a/src/components/UnifiedSearch.jsx
+++ b/src/components/UnifiedSearch.jsx
@@ -406,13 +406,7 @@ export default function UnifiedSearch() {
     <CuratedResults results={curatedResults} loadError={curatedError} />
   ) : null;
 
-  const items = [
-    {
-      key: "2",
-      label: "Computed Image Matches",
-      children: computedMatches,
-    },
-  ];
+  const items = [];
 
   if (curatedResults.length > 0) {
     items.unshift({
@@ -431,23 +425,29 @@ export default function UnifiedSearch() {
   }
 
   return (
-    <div style={{"margin": "auto", "maxWidth": "1400px"}}>
+    <div style={{ margin: "auto", maxWidth: "1400px" }}>
       <SearchInput searchTerm={searchTerm} />
       {!searchTerm ? (
         <NoSearch />
       ) : (
-        <div style={{'position':'relative'}}>
-          { curatedResults.length > 0 ? (<FontAwesomeIcon
-            icon={faBookmark}
-            style={{
-              position: "absolute",
-              top: "-3px",
-              left: "5px",
-              color: "#f00",
-              fontSize: "1.5em",
-            }}
-          />): null}
-          <Collapse items={items} defaultActiveKey={["1", "2"]} />
+        <div style={{ position: "relative" }}>
+          {curatedResults.length > 0 ? (
+            <FontAwesomeIcon
+              icon={faBookmark}
+              style={{
+                position: "absolute",
+                top: "-3px",
+                left: "5px",
+                color: "#f00",
+                fontSize: "1.5em",
+              }}
+            />
+          ) : null}
+          {curatedResults.length > 0 ? (
+            <Collapse items={items} defaultActiveKey={["1", "2"]} />
+          ) : null}
+          <br />
+          {computedMatches}
         </div>
       )}
     </div>

--- a/src/components/UnifiedSearch.jsx
+++ b/src/components/UnifiedSearch.jsx
@@ -3,7 +3,7 @@ import { useLocation, Link } from "react-router-dom";
 import { Storage, Auth, API } from "aws-amplify";
 import { Collapse, Spin, message, Typography } from "antd";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faBookmark } from "@fortawesome/pro-solid-svg-icons";
+import { faBookmark } from "@fortawesome/free-solid-svg-icons";
 
 import SearchInput from "./SearchInput";
 import UnifiedSearchResults from "./UnifiedSearchResults";
@@ -271,7 +271,7 @@ export default function UnifiedSearch() {
                 ) {
                   return match.bodyIDs.map((body) => {
                     publishedNames.add(body);
-                    const [bodyID] = Object.entries(body)[0];
+                    const bodyID = body.split(":").at(-1);
                     // skip if we have already seen this bodyID in one of the other
                     // matches. This happens when we use wildcard searches that return
                     // results for both the neuron type and the neuron instance. eg: LHPD2c7*

--- a/src/components/UnifiedSearch.jsx
+++ b/src/components/UnifiedSearch.jsx
@@ -1,13 +1,16 @@
 import React, { useState, useEffect, useContext } from "react";
 import { useLocation, Link } from "react-router-dom";
 import { Storage, Auth, API } from "aws-amplify";
-import { Spin, message, Typography } from "antd";
+import { Collapse, Spin, message, Typography } from "antd";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faBookmark } from "@fortawesome/pro-solid-svg-icons";
 
 import SearchInput from "./SearchInput";
 import UnifiedSearchResults from "./UnifiedSearchResults";
 import CuratedResults from "./CuratedResults";
 import NoSearch from "./NoSearch";
 import { AppContext } from "../containers/AppContext";
+import HelpButton from "./Help/HelpButton";
 import { setResultsFullUrlPaths } from "../libs/utils";
 
 const { Title, Paragraph } = Typography;
@@ -24,6 +27,53 @@ function splitOnLastOccurrence(str, substring) {
   return [before, after];
 }
 
+function filterAndSortCuratedMatches(matches) {
+  // expand the matches.
+  const expanded = matches.flatMap((match) => {
+    if (match.itemType === "line_name") {
+      return match.matches.map((m) => ({
+        name: match.name,
+        confidence: m.annotation,
+        anatomicalRegion: m.region,
+        cellType: m.cell_type,
+      }));
+    }
+    if (match.itemType === "cell_type") {
+      return match.matches.map((m) => ({
+        name: m.line,
+        confidence: m.annotation,
+        anatomicalRegion: m.region,
+        cellType: match.name,
+      }));
+    }
+    return [];
+  });
+
+  // strip duplicates if cellType and name are the same
+  const deduped = expanded.filter(
+    (v, i, a) =>
+      a.findIndex((t) => t.cellType === v.cellType && t.name === v.name) === i,
+  );
+  // sort by name and then confidence, where confident comes before candidate.
+  deduped.sort((a, b) => {
+    if (a.confidence === "Confident" && b.confidence === "Candidate") {
+      return -1;
+    }
+    if (a.confidence === "Candidate" && b.confidence === "Confident") {
+      return 1;
+    }
+
+    if (a.name < b.name) {
+      return -1;
+    }
+    if (a.name > b.name) {
+      return 1;
+    }
+    return 0;
+  });
+  return deduped;
+}
+
 export default function UnifiedSearch() {
   const query = useQuery();
   const searchTerm = query.get("q") || "";
@@ -35,6 +85,10 @@ export default function UnifiedSearch() {
   const [loadError, setLoadError] = useState(false);
   const [bodyLoading, setBodyLoading] = useState(false);
   const [foundItems, setFoundItems] = useState(0);
+
+  const [curatedResults, setCuratedResults] = useState([]);
+  const [curatedError, setCuratedError] = useState(false);
+
   const { appState } = useContext(AppContext);
 
   // strip out the dataset from the body id if present and run the
@@ -46,6 +100,7 @@ export default function UnifiedSearch() {
     ":",
   );
 
+  // load the computed matches
   useEffect(() => {
     function readMetaData(metaData, combinedResults, setResults) {
       return new Promise((resolve, reject) => {
@@ -273,6 +328,29 @@ export default function UnifiedSearch() {
     searchDataset,
   ]);
 
+  useEffect(() => {
+    if (searchTerm !== "") {
+      setCuratedResults([]);
+      Auth.currentCredentials().then(() => {
+        setCuratedError(false);
+        API.get("SearchAPI", "/curated_matches", {
+          queryStringParameters: {
+            q: searchTerm,
+          },
+        })
+          .then((response) => {
+            if (response.matches.length > 0) {
+              const sorted = filterAndSortCuratedMatches(response.matches);
+              setCuratedResults(sorted);
+            }
+          })
+          .catch((error) => {
+            setCuratedError(error);
+          });
+      });
+    }
+  }, [searchTerm]);
+
   const searchError = (
     <div>
       <Title>System Error</Title>
@@ -288,51 +366,89 @@ export default function UnifiedSearch() {
     </div>
   );
 
+  let computedMatches = null;
+
+  if (loadError) {
+    computedMatches = searchError;
+  } else if (byLineResult && byBodyResult && !lineLoading && !bodyLoading) {
+    computedMatches = (
+      <>
+        <UnifiedSearchResults
+          searchTerm={searchTerm}
+          linesResult={byLineResult}
+          skeletonsResult={byBodyResult}
+        />
+        {foundItems > byBodyResult.results.length ? (
+          <p>
+            <b>
+              There are additional matches for your search term in different
+              datasets. To view them search for &lsquo;
+              <Link to={`/search?q=${searchBodyIdOrName}`}>
+                {searchBodyIdOrName}
+              </Link>
+              &rsquo;
+            </b>
+          </p>
+        ) : (
+          ""
+        )}
+      </>
+    );
+  } else if (lineLoading || (bodyLoading && !loadError)) {
+    computedMatches = (
+      <div>
+        <Spin tip="Loading..." size="large" /> Loading...
+      </div>
+    );
+  }
+
+  const curatedMatches = searchTerm ? (
+    <CuratedResults results={curatedResults} loadError={curatedError} />
+  ) : null;
+
+  const items = [
+    {
+      key: "2",
+      label: "Computed Image Matches",
+      children: computedMatches,
+    },
+  ];
+
+  if (curatedResults.length > 0) {
+    items.unshift({
+      key: "1",
+      label: "Curated Matches",
+      children: curatedMatches,
+      extra: (
+        <HelpButton
+          target="CuratedResults"
+          onClick={(event) => {
+            event.stopPropagation();
+          }}
+        />
+      ),
+    });
+  }
+
   return (
     <div>
       <SearchInput searchTerm={searchTerm} />
-      {!searchTerm ? <NoSearch /> : ""}
-      {searchTerm ? (
-        <>
-          <CuratedResults searchTerm={searchTerm} />
-          <h2 className="antd-card-head-title">Computed Image Matches</h2>
-        </>
+      {!searchTerm ? (
+        <NoSearch />
       ) : (
-        ""
-      )}
-      {(lineLoading || bodyLoading) && !loadError ? (
-        <div>
-          <Spin tip="Loading..." size="large" /> Loading...
+        <div style={{'position':'relative'}}>
+          { curatedResults.length > 0 ? (<FontAwesomeIcon
+            icon={faBookmark}
+            style={{
+              position: "absolute",
+              top: "-3px",
+              left: "5px",
+              color: "#f00",
+              fontSize: "1.5em",
+            }}
+          />): null}
+          <Collapse items={items} defaultActiveKey={["1", "2"]} />
         </div>
-      ) : (
-        ""
-      )}
-      {loadError ? searchError : ""}
-
-      {byLineResult && byBodyResult && !lineLoading && !bodyLoading ? (
-        <>
-          <UnifiedSearchResults
-            searchTerm={searchTerm}
-            linesResult={byLineResult}
-            skeletonsResult={byBodyResult}
-          />
-          {foundItems > byBodyResult.results.length ? (
-            <p>
-              <b>
-                There are additional matches for your search term in different
-                datasets. To view them search for &lsquo;
-                <Link to={`/search?q=${searchBodyIdOrName}`}>
-                  {searchBodyIdOrName}
-                </Link>
-                &rsquo;
-              </b>
-            </p>
-          ) : (
-            ""
-          )}
-        </>
-      ) : (
-        ""
       )}
     </div>
   );

--- a/src/components/UnifiedSearch.jsx
+++ b/src/components/UnifiedSearch.jsx
@@ -431,7 +431,7 @@ export default function UnifiedSearch() {
   }
 
   return (
-    <div>
+    <div style={{"margin": "auto", "maxWidth": "1400px"}}>
       <SearchInput searchTerm={searchTerm} />
       {!searchTerm ? (
         <NoSearch />

--- a/src/components/UnifiedSearchResults.jsx
+++ b/src/components/UnifiedSearchResults.jsx
@@ -151,7 +151,7 @@ export default function UnifiedSearchResults(props) {
               onChange={(newPage) => handlePageChange(newPage)}
               total={resultsList.length}
               showTotal={(total, range) =>
-                `Results ${range[0]}-${range[1]} of ${total}`
+                `Query Results ${range[0]}-${range[1]} of ${total}`
               }
             />
           </Col>
@@ -169,7 +169,7 @@ export default function UnifiedSearchResults(props) {
           onChange={(newPage) => handlePageChange(newPage)}
           total={resultsList.length}
           showTotal={(total, range) =>
-            `Results ${range[0]}-${range[1]} of ${total}`
+            `Query Results ${range[0]}-${range[1]} of ${total}`
           }
         />
       </div>

--- a/src/components/__tests__/SearchInput.jsx
+++ b/src/components/__tests__/SearchInput.jsx
@@ -12,7 +12,7 @@ describe("SearchInput: unit tests", () => {
         <SearchInput />
       </MemoryRouter>
     );
-    expect(getByText('Search'));
+    expect(getByText('Query'));
   });
 
   /* had to disable the accessibility test, because it throws an error due to

--- a/src/mocks/handlers.js
+++ b/src/mocks/handlers.js
@@ -1,8 +1,8 @@
 import { rest } from "msw";
 import publishedNames12288 from "./published_names_12288.json";
-import devPreConfig from "./dev_pre_config.json";
-import refsJSON from "./refs.json";
 /*
+import refsJSON from "./refs.json";
+import devPreConfig from "./dev_pre_config.json";
 import metadata1537331894 from "./1537331894_metadata.json";
 import LH173metadata from "./LH173_metadata.json";
 import R16F12metadata from "./R16F12_metadata.json";
@@ -28,63 +28,65 @@ export const handlers = [
     },
   ),
 
-  rest.get(
+  /* rest.get(
     "https://janelia-neuronbridge-data-devpre.s3.us-east-1.amazonaws.com/v3_0_0/config.json",
     (req, res, ctx) => res(ctx.status(200), ctx.json(devPreConfig)),
   ),
   rest.get(
     "https://cmcg8hqwd1.execute-api.us-east-1.amazonaws.com/curated_matches",
     (req, res, ctx) => {
-      console.log(req.url.searchParams.get("q"));
-      return res(
-        ctx.status(200),
-        ctx.json({
-          curated_matches: [
-            {
-              search_term: "MB018B",
-              name: "MB018B",
-              confidence: "candidate",
-              anatomicalRegion: "Brain",
-              cellType: "KCg-d",
-            },
-            {
-              search_term: "MB018B",
-              name: "MB018B",
-              confidence: "candidate",
-              anatomicalRegion: "Brain",
-              cellType: "KCg-m",
-            },
-            {
-              search_term: "KCg-m",
-              name: "MB018B",
-              confidence: "candidate",
-              anatomicalRegion: "Brain",
-              cellType: "KCg-m",
-            },
-            {
-              search_term: "MB018B",
-              name: "MB018B",
-              confidence: "confident",
-              anatomicalRegion: "Brain",
-              cellType: "MBON13",
-            },
-            {
-              search_term: "KCg-F",
-              name: "MB016G",
-              confidence: "candidate",
-              anatomicalRegion: "VNC",
-              cellType: "KCg-F",
-            },
-            {
-              search_term: "MB017C",
-              name: "MB017C",
-              confidence: "confident",
-              anatomicalRegion: "Brain",
-              cellType: "KCg-F",
-            },
-          ],
-        }),
-      );
+      if (req.url.searchParams.get("search_term") === "MB018B") {
+        return res(
+          ctx.status(200),
+          ctx.json({
+            matches: [
+              {
+                search_term: "MB018B",
+                name: "MB018B",
+                confidence: "candidate",
+                anatomicalRegion: "Brain",
+                cellType: "KCg-d",
+              },
+              {
+                search_term: "MB018B",
+                name: "MB018B",
+                confidence: "candidate",
+                anatomicalRegion: "Brain",
+                cellType: "KCg-m",
+              },
+              {
+                search_term: "KCg-m",
+                name: "MB018B",
+                confidence: "candidate",
+                anatomicalRegion: "Brain",
+                cellType: "KCg-m",
+              },
+              {
+                search_term: "MB018B",
+                name: "MB018B",
+                confidence: "confident",
+                anatomicalRegion: "Brain",
+                cellType: "MBON13",
+              },
+              {
+                search_term: "KCg-F",
+                name: "MB016G",
+                confidence: "candidate",
+                anatomicalRegion: "VNC",
+                cellType: "KCg-F",
+              },
+              {
+                search_term: "MB017C",
+                name: "MB017C",
+                confidence: "confident",
+                anatomicalRegion: "Brain",
+                cellType: "KCg-F",
+              },
+            ],
+          }),
+        );
+      }
+      return req.passthrough()
     },
   ),
   rest.get(

--- a/src/mocks/handlers.js
+++ b/src/mocks/handlers.js
@@ -18,19 +18,74 @@ import results2988247185125302403 from "./2988247185125302403.json";
 
 /* eslint-disable-next-line import/prefer-default-export */
 export const handlers = [
-   rest.get(
+  rest.get(
     "https://tj19qkjsxh.execute-api.us-east-1.amazonaws.com/published_names",
     (req, res, ctx) => {
-      if (req.url.searchParams.get('q') === '12288') {
+      if (req.url.searchParams.get("q") === "12288") {
         return res(ctx.status(200), ctx.json(publishedNames12288));
       }
       return req.passthrough();
-    }
+    },
   ),
 
   rest.get(
-		"https://janelia-neuronbridge-data-devpre.s3.us-east-1.amazonaws.com/v3_0_0/config.json",
-    (req, res, ctx) => res(ctx.status(200), ctx.json(devPreConfig))
+    "https://janelia-neuronbridge-data-devpre.s3.us-east-1.amazonaws.com/v3_0_0/config.json",
+    (req, res, ctx) => res(ctx.status(200), ctx.json(devPreConfig)),
+  ),
+  rest.get(
+    "https://cmcg8hqwd1.execute-api.us-east-1.amazonaws.com/curated_matches",
+    (req, res, ctx) => {
+      console.log(req.url.searchParams.get("q"));
+      return res(
+        ctx.status(200),
+        ctx.json({
+          curated_matches: [
+            {
+              search_term: "MB018B",
+              name: "MB018B",
+              confidence: "candidate",
+              anatomicalRegion: "Brain",
+              cellType: "KCg-d",
+            },
+            {
+              search_term: "MB018B",
+              name: "MB018B",
+              confidence: "candidate",
+              anatomicalRegion: "Brain",
+              cellType: "KCg-m",
+            },
+            {
+              search_term: "KCg-m",
+              name: "MB018B",
+              confidence: "candidate",
+              anatomicalRegion: "Brain",
+              cellType: "KCg-m",
+            },
+            {
+              search_term: "MB018B",
+              name: "MB018B",
+              confidence: "confident",
+              anatomicalRegion: "Brain",
+              cellType: "MBON13",
+            },
+            {
+              search_term: "KCg-F",
+              name: "MB016G",
+              confidence: "candidate",
+              anatomicalRegion: "VNC",
+              cellType: "KCg-F",
+            },
+            {
+              search_term: "MB017C",
+              name: "MB017C",
+              confidence: "confident",
+              anatomicalRegion: "Brain",
+              cellType: "KCg-F",
+            },
+          ],
+        }),
+      );
+    },
   ),
   rest.get(
     "https://janelia-neuronbridge-data-dev.s3.us-east-1.amazonaws.com/v3_3_2/refs.json",


### PR DESCRIPTION
- **feat: Adds basic example of curated results table.**
- **feat: Adds Curated Results section to help.**
- **feat: Adds API endpoint fetch to CuratedResults.**
- **feat: Fixes up curated matches processing.**
- **feat: Places curated matches in a collapsible element**
- **feat: adds pagination to the curate matches table.**
- **feat: curated matches sets page size to 5**
- **fix: removes card border around curated matches error**
- **fix: Changes title of curated matches container.**
- **fix: Constrains maximum width of search results.**
- **feat: Adds "search" link to Neuron type/instance**
- **fix: Removes collapse box around computed matches.**
- **feat: Adds "Source" column to curated results.**
- **fix: sets default to 2 items per page for curated results.**
- **fix: Changes 'Search' button to 'Query' button.**
- **fix: hides pagination when curated results <= 2.**
- **testing: fix SearchInput tests after button name change**
- **feat: Adds EM annotations to curated matches table**
- **fix: reduce allowed search term length to 2 from 3**
- **fix: Adds a wildcard to the end of all curated cell_types**
- **fix: Adds addWildCard attribute to curated matches**
- **fix: removes incorrect "Additional matches ...." message**
- **fix: Moves curated matches pagination to table bottom.**
- **fix: Makes curated match count bold to highlight it.**
- **added help text for curated matches from Geoffrey**
- **updated paper reference**
- **updated search examples to include more curated matches**
- **fix: restore bodyID string parsing broken during rebase**
- **feat: add @fortawesome/free-solid-svg-icons dependency**
- **feat: make line name a link to search page in LineMeta**
- **chore: bump version to 3.5.0 and add 3.4.0 release notes**
- **docs: add 3.5.0 release notes**
- **fix: scroll to hash anchor on mount instead of page top**
- **chore: Updated release notes to remove unnecessary details**
@krokicki 